### PR TITLE
remove putenv:scan_cacheable=true

### DIFF
--- a/watcher.php
+++ b/watcher.php
@@ -18,8 +18,6 @@ date_default_timezone_set('Asia/Shanghai');
 ! defined('BASE_PATH') && define('BASE_PATH', getcwd());
 ! defined('SWOOLE_HOOK_FLAGS') && define('SWOOLE_HOOK_FLAGS', SWOOLE_HOOK_ALL);
 
-putenv('SCAN_CACHEABLE=(true)');
-
 require BASE_PATH . '/vendor/autoload.php';
 
 Hyperf\Di\ClassLoader::init();


### PR DESCRIPTION
scan_cacheable=true导致server:watch执行过程中,新建php文件,注入@Inject失败.  
原因:
src/Annotation/ScanConfig.php line:174  受默认参数scan_cacheable影响,导致classes.cache未更新.   可通过.env或配置中心去直接管理