### PR TITLE
fix: invalid composer command when app reloaded

### DIFF
--- a/src/Watcher.php
+++ b/src/Watcher.php
@@ -86,7 +86,7 @@ class Watcher
 
     public function dumpautoload()
     {
-        $ret = System::exec('composer dump-autoload -o --no-scripts -d ' . BASE_PATH);
+        $ret = System::exec('composer dump-autoload -o -d ' . BASE_PATH);
         $this->output->writeln($ret['output'] ?? '');
     }
 


### PR DESCRIPTION
bugs `runtime/container` folder doesn't removed when hot reload triggered